### PR TITLE
version 2.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <packaging>jar</packaging>
   <groupId>org.webjars</groupId>
   <artifactId>cometd</artifactId>
-  <version>3.0.10-SNAPSHOT</version>
+  <version>2.8.0-SNAPSHOT</version>
   <name>cometd</name>
   <description>WebJar for cometd</description>
   <url>http://webjars.org</url>


### PR DESCRIPTION
Hello,

I have an application in production running version 2.8.0 of cometd. This project had all of the JavaScript dependencies checked directly into the repository, and I am going through the effort of moving them out to webjars. I noticed that there was a previous request to support an old version of cometd which was granted, so hopefully this PR is acceptable. I ran a mvn package locally and it seemed to work OK. 

Please let me know if there's any changes I need to make in order to get this accepted.

Thanks,
Andrew